### PR TITLE
Remove hard-coded Emacs configuration path

### DIFF
--- a/README.org
+++ b/README.org
@@ -70,7 +70,7 @@ Before using this package, ~org-fc-directories~
 should be set to the directory to search for org files containing flashcards.
 
 The file used to store the review history can be customized with
-~org-fc-review-history-file~ and defaults to ~.emacs.d/org-fc-reviews.tsv~.
+~org-fc-review-history-file~ and defaults to ~/path/to/config/org-fc-reviews.tsv~.
 
 This package is not (yet) available on MELPA / ELPA,
 to install it, clone the repository (e.g. to ~src/org-fc/~)

--- a/org-fc.el
+++ b/org-fc.el
@@ -45,7 +45,7 @@
   "Location of the org-fc sources, used to generate absolute
   paths to the awk scripts")
 
-(defcustom org-fc-review-history-file "~/.emacs.d/org-fc-reviews.tsv"
+(defcustom org-fc-review-history-file (expand-file-name "org-fc-reviews.tsv" user-emacs-directory)
   "File to store review results in."
   :type 'string
   :group 'org-fc)


### PR DESCRIPTION
Emacs is moving to ~/.config/emacs soon, this guards against that.