### PR TITLE
Improved Spacing Algorithm

### DIFF
--- a/README.org
+++ b/README.org
@@ -289,7 +289,7 @@ upcoming changes.
 In case a update to the org sources is needed, I'll add a changelog
 entry with updating instructions.
 
-*** [2020-04-21 Tue]
+*** [2020-04-29 Wed]
 Implemented a new version of the spacing algorithm (SM2) that's used
 by org-fc.
 
@@ -304,7 +304,10 @@ In the new version (~'sm2-v2~), the interval is always multiplied by a
 factor of 1.2, similar to the version of SM2 used by Anki.
 
 ~org-fc-algorithm~ can be used to set which version of the
-algorithm should be used, defaulting to ~'sm2-v2~.
+algorithm should be used, defaulting to ~'sm2-v1~.
+
+Once I have evaluated the performance of the new algorithm,
+the default version will change to ~'sm2-v2~.
 *** [2020-04-12 Sun]
 **** Added
 - =text-input= card type

--- a/README.org
+++ b/README.org
@@ -289,12 +289,31 @@ upcoming changes.
 In case a update to the org sources is needed, I'll add a changelog
 entry with updating instructions.
 
-*** [2020-02-08 Sat 15:22]
+*** [2020-04-21 Tue]
+Implemented a new version of the spacing algorithm (SM2) that's used
+by org-fc.
+
+The only difference is in how the next interval for cards rated as
+"hard" is calculate.
+
+The initial version (~'sm2-v1~) would decrease the ease factor by
+0.15, then calculate the next interval by multiplying the previous
+interval with the new ease factor.
+
+In the new version (~'sm2-v2~), the interval is always multiplied by a
+factor of 1.2, similar to the version of SM2 used by Anki.
+
+~org-fc-algorithm~ can be used to set which version of the
+algorithm should be used, defaulting to ~'sm2-v2~.
+*** [2020-04-12 Sun]
+**** Added
+- =text-input= card type
+*** [2020-02-08 Sat]
 **** Changed
 - Add a "Z" suffix to all ISO8601 timestamps
 **** Added
 - A function to estimate the number of reviews in the next n days
-*** [2020-02-03 Mon 15:15]
+*** [2020-02-03 Mon]
 **** Internal
 - ~org-fc-due-positions-for-paths~ now shuffles the lists of positions
   using an Emacs Lisp function instead of depending on =shuf=

--- a/org-fc.el
+++ b/org-fc.el
@@ -131,7 +131,7 @@ Used to generate absolute paths to the awk scripts.")
 
 ;;;; Spacing Parameters
 
-(defcustom org-fc-algorithm 'sm2-v2
+(defcustom org-fc-algorithm 'sm2-v1
   "Algorithm for spacing reviews of cards."
   :type '(choice (const sm2-v1) (const sm2-v2))
   :group 'org-fc)


### PR DESCRIPTION
Analyzing review performance over the 126k reviews I've done so far,
I've noticed that the review performance is worse for cards that have been rated "hard" in the previous review.

![reviews_by_prev](https://user-images.githubusercontent.com/2060269/80597618-5e154a80-8a28-11ea-9df0-af1e6eb67ffc.png)

To solve this problem, the next review interval after a "hard" review should be smaller.
In the current spacing algorithm, a cards ease is decreased by 0.15,
then the next interval is calculated by multiplying the last interval with this new ease.

This pull request adds a new variant of the spacing algorithm
that uses a fixed factor of 1.2 instead, similar to the spacing algorithm used by Anki.

For now, by default the old algorithm (`sm2-v1`) is used,
the new algorithm can be enabled with `(setq org-fc-algorithm 'sm2-v2)`.

Once I've collected enough data to verify that the new algorithm solves the problem,
the default will change to `sm-v2`.