### PR TITLE
fix find on symlinks

### DIFF
--- a/org-fc.el
+++ b/org-fc.el
@@ -1196,7 +1196,7 @@ Checks if the headline is a suspended card first."
 Matches all .org files ignoring ones with names don't start with
 a '.' to exclude temporary / backup files."
   (format
-   "find %s -name \"*.org\" -not -name \".*\" -print0"
+   "find -L %s -name \"*.org\" -not -name \".*\" -print0"
    (mapconcat 'identity paths " ")))
 
 (defun org-fc-awk--indexer-variables ()


### PR DESCRIPTION
Close #26 

I don't think this should break anything.

> `-L`
> find dereferences symbolic links where possible, and where this is not possible it uses the properties of the symbolic link itself. This option must be specified before any of the file names on the command line. Use of this option also implies the same behaviour as the ‘-noleaf’ option. If you later use the ‘-H’ or ‘-P’ options, this does not turn off ‘-noleaf’.
> 
> Actions that can cause symbolic links to become broken while ‘find’ is executing (for example ‘-delete’) can give rise to confusing behaviour. Take for example the command line ‘find -L . -type d -delete’. This will delete empty directories. If a subtree includes only directories and symbolic links to directoires, this command may still not successfully delete it, since deletion of the target of the symbolic link will cause the symbolic link to become broken and ‘-type d’ is false for broken symbolic links.