### PR TITLE
Mode based review

### DIFF
--- a/README.org
+++ b/README.org
@@ -405,6 +405,9 @@ upcoming changes.
 In case a update to the org sources is needed, I'll add a changelog
 entry with updating instructions.
 
+*** [2020-06-25 Thu]
+**** Changed
+During the review process, two minor modes are used instead of two hydras.
 *** [2020-05-24 Sun]
 **** Changed
 - Include file information in card index

--- a/README.org
+++ b/README.org
@@ -290,15 +290,52 @@ Ideally, don't use any other hotkeys while in a review session.
 This exits the review hydra without ending the current review session
 making it necessary to do so manually (~org-fc-review-quit~).
 
-~org-fc-tag-card~ can be used on a card heading or during review
-to add one of the ~org-fc-card-tags~ to the card.
 
-Tags can be added to this list using ~(add-to-list 'org-fc-card-tags
-"my-tag")~.
+Flip mode:
+
+| Key | Binding      |
+|-----+--------------|
+| RET | flip card    |
+| n   | flip card    |
+| s   | suspend card |
+| q   | quit review  |
+
+Rate mode:
+
+| Key | Binding      |
+|-----+--------------|
+| a   | rate again   |
+| h   | rate hard    |
+| g   | rate good    |
+| e   | rate easy    |
+| s   | suspend card |
+| q   | quit review  |
 
 See also:
 - [[file:doc/review_internals.org][Review Internals]]
 - [[file:doc/review_history.org][Review History]]
+** Use with =evil-mode=
+The key bindings used by the review modes of org-fc conflict with
+some of the bindings used by evil mode.
+
+As a workaround, you can add minor mode keymaps for
+each of the evil-mode states you're using org-fc with.
+
+#+begin_src emacs-lisp
+(evil-define-minor-mode-key '(normal insert emacs) 'org-fc-review-flip-mode
+  (kbd "RET") 'org-fc-review-flip
+  (kbd "n") 'org-fc-review-flip
+  (kbd "s") 'org-fc-review-suspend-card
+  (kbd "q") 'org-fc-review-quit)
+
+(evil-define-minor-mode-key '(normal insert emacs) 'org-fc-review-rate-mode
+  (kbd "a") 'org-fc-review-rate-again
+  (kbd "h") 'org-fc-review-rate-hard
+  (kbd "g") 'org-fc-review-rate-good
+  (kbd "e") 'org-fc-review-rate-easy
+  (kbd "s") 'org-fc-review-suspend-card
+  (kbd "q") 'org-fc-review-quit)
+#+end_src
 ** Review Contexts
 By default, two contexts are defined:
 

--- a/README.org
+++ b/README.org
@@ -266,42 +266,27 @@ See also:
 - [[https://apps.ankiweb.net/docs/manual.html#what-algorithm][Anki Manual - Algorithm]]
 - [[https://www.supermemo.com/en/archives1990-2015/english/ol/sm2][SuperMemo - SM2 Algorithm]]
 ** Review
-Reviewing cards is done by opening the file the card is in,
-using a special narrowing function to hide other headings
-and drawers.
+A review session can be started with ~M-x org-fc-review~.
 
-With ~(point)~ on the headline to be reviewed,
-the setup function for this card type is called
-(e.g. to hide the cloze holes of the card).
+Due cards are reviewed in random order.
 
-Then the flip function for the card type is called,
-usually opening a *hydra* showing available hotkeys.
-
-Once the card is flipped, another hydra for rating the card is shown.
-
-A review session can be started using ~org-fc-review-all~
-to review all cards that are due, or using ~org-fc-review-buffer~ to
-review only cards in the current buffer.
-
-The current review session can be ended / reset using
-~org-fc-review-quit~.
-
-Ideally, don't use any other hotkeys while in a review session.
-This exits the review hydra without ending the current review session
-making it necessary to do so manually (~org-fc-review-quit~).
-
-
-Flip mode:
-
+*** Review Process
+1. Open file of card
+2. Narrow to heading
+3. Set up card for review
+4. Activate ~org-fc-flip-mode~
+5. Flip the card (user)
+6. Switch to ~org-fc-rate-mode~
+7. Rate the card (user)
+8. Repeat process with next due card
+*** Flip Mode
 | Key | Binding      |
 |-----+--------------|
 | RET | flip card    |
 | n   | flip card    |
 | s   | suspend card |
 | q   | quit review  |
-
-Rate mode:
-
+*** Rate Mode
 | Key | Binding      |
 |-----+--------------|
 | a   | rate again   |
@@ -310,8 +295,7 @@ Rate mode:
 | e   | rate easy    |
 | s   | suspend card |
 | q   | quit review  |
-
-See also:
+*** See Also
 - [[file:doc/review_internals.org][Review Internals]]
 - [[file:doc/review_history.org][Review History]]
 ** Use with =evil-mode=

--- a/org-fc-hydra.el
+++ b/org-fc-hydra.el
@@ -25,6 +25,7 @@
 ;;; Code:
 
 (require 'org-fc)
+(require 'hydra)
 
 (defhydra org-fc-hydra ()
   ("m" org-fc-dashboard "Dashboard" :exit t)

--- a/org-fc.el
+++ b/org-fc.el
@@ -110,11 +110,6 @@ types."
   :type 'string
   :group 'org-fc)
 
-(defcustom org-fc-card-tags (list org-fc-suspended-tag)
-  "Card tags that can be added during review."
-  :type 'list
-  :group 'org-fc)
-
 (defcustom org-fc-stats-review-min-box 0
   "Minimum box for reviews to include in the review stats."
   :type 'integer
@@ -503,12 +498,6 @@ If it is shorter than EXPECTED-LENGTH, it is filled using
   "Add TAG to the heading at point."
   (org-set-tags
    (remove tag (org-get-tags nil 'local))))
-
-;;;###autoload
-(defun org-fc-tag-card (tag)
-  "Add one of the predefined card TAGs to the current card."
-  (interactive (list (completing-read "Tag: " org-fc-card-tags)))
-  (org-fc--add-tag tag))
 
 ;;; Card Initialization
 

--- a/org-fc.el
+++ b/org-fc.el
@@ -1761,7 +1761,6 @@ Valid contexts:
                 (org-fc-set-header-line)
 
                 (goto-char (point-min))
-                (org-fc-show-all)
                 (org-fc-id-goto id path)
 
                 (org-fc-indent)
@@ -1826,9 +1825,7 @@ same ID as the current card in the session."
                (delta (- now org-fc-timestamp)))
           (org-fc-session-add-rating org-fc-review--current-session rating)
           (org-fc-review-update-data path id position rating delta)
-          (org-fc-show-all)
-          (org-fc-reset-header-line)
-          (org-fc-review-rate-mode -1)
+          (org-fc-review-reset)
           (save-buffer)
           (unless org-fc-reviewing-existing-buffer
             (kill-buffer))
@@ -1861,6 +1858,7 @@ same ID as the current card in the session."
   "Suspend card and proceed to next."
   (interactive)
   (org-fc-suspend-card)
+  (org-fc-review-reset)
   (org-fc-review-next-card))
 
 (defun org-fc-review-update-data (path id position rating delta)
@@ -1902,15 +1900,19 @@ rating the card."
                   (org-fc-timestamp-in next-interval)))
            (org-fc-set-review-data data)))))))
 
+(defun org-fc-review-reset ()
+  "Reset the buffer to its state before the review."
+  (org-fc-review-rate-mode -1)
+  (org-fc-review-flip-mode -1)
+  (org-fc-reset-header-line)
+  (org-fc-show-all))
+
 ;;;###autoload
 (defun org-fc-review-quit ()
   "Quit the review, remove all overlays from the buffer."
   (interactive)
-  (org-fc-review-rate-mode -1)
-  (org-fc-review-flip-mode -1)
-  (setq org-fc-review--current-session nil)
-  (org-fc-reset-header-line)
-  (org-fc-show-all))
+  (org-fc-review-reset)
+  (setq org-fc-review--current-session nil))
 
 ;;; Dashboard
 

--- a/org-fc.el
+++ b/org-fc.el
@@ -29,13 +29,12 @@
 (require 'cl-lib)
 (require 'eieio)
 (require 'org-id)
+(require 'org-indent)
 (require 'org-element)
 (require 'outline)
 (require 'parse-time)
 (require 'subr-x)
 (require 'svg)
-
-(require 'hydra)
 
 ;;; Customization
 

--- a/org-fc.el
+++ b/org-fc.el
@@ -1770,6 +1770,26 @@ same ID as the current card in the session."
      (org-fc-review-quit)
      (signal (car err) (cdr err)))))
 
+(defun org-fc-review-rate-again ()
+  "Rate the card at point with 'again'."
+  (interactive)
+  (org-fc-review-rate-card 'again))
+
+(defun org-fc-review-rate-hard ()
+  "Rate the card at point with 'hard'."
+  (interactive)
+  (org-fc-review-rate-card 'hard))
+
+(defun org-fc-review-rate-good ()
+  "Rate the card at point with 'good'."
+  (interactive)
+  (org-fc-review-rate-card 'good))
+
+(defun org-fc-review-rate-easy ()
+  "Rate the card at point with 'easy'."
+  (interactive)
+  (org-fc-review-rate-card 'easy))
+
 (defun org-fc-review-suspend-card ()
   "Suspend card and proceed to next."
   (interactive)


### PR DESCRIPTION
Change the review process to use two minor modes instead of two hydras.

This allows customization of review key bindings.