### PR TITLE
Add org-fc-max-positions-per-review

### DIFF
--- a/awk/index.awk
+++ b/awk/index.awk
@@ -9,6 +9,7 @@ BEGIN {
     suspended_tag = ":" or_default(suspended_tag, "suspended") ":";
     review_data_drawer = ":" or_default(review_data_drawer, "REVIEW_DATA") ":";
     type_property = or_default(type_property, "FC_TYPE");
+    cloze_type_property = or_default(cloze_type_property, "FC_CLOZE_TYPE");
     created_property = or_default(created_property, "FC_CREATED");
 
     # Small state machine to make sure cards are in the correct format
@@ -118,10 +119,15 @@ $0 ~ review_data_drawer {
         }
         local_tags = parent_tags[level];
 
+        cloze_type = ""
+        if (cloze_type_property in properties)
+            cloze_type = " :cloze-type " properties[cloze_type_property]
+
         print "    (" \
             ":id " escape_string(properties["ID"])  \
             " :title " escape_string(title)  \
             " :type " properties[type_property]     \
+            cloze_type                                            \
             " :created " parse_time(properties[created_property]) \
             " :suspended " (suspended ? "t" : "nil")   \
             " :inherited-tags " escape_string(inherited_tags)  \

--- a/org-fc.el
+++ b/org-fc.el
@@ -76,6 +76,11 @@ Used to generate absolute paths to the awk scripts.")
   :type 'string
   :group 'org-fc)
 
+(defcustom org-fc-cloze-type-property "FC_CLOZE_TYPE"
+  "Property used to store the card's subtype for cloze cards."
+  :type 'string
+  :group 'org-fc)
+
 (defcustom org-fc-created-property "FC_CREATED"
   "Property used to store the cards creation time."
   :type 'string
@@ -189,6 +194,12 @@ Values are in days."
 (defcustom org-fc-sm2-fuzz-max 1.1
   "Upper bound for random interval fuzz factor."
   :type 'float
+  :group 'org-fc)
+
+(defcustom org-fc-bury-siblings nil
+  "Whether or not multiple positions of the same card should be shown during
+review. Does not apply to cloze single and cloze enumeration cards."
+  :type 'boolean
   :group 'org-fc)
 
 ;;;; Hooks
@@ -1228,6 +1239,7 @@ With the '-L' option, 'find' follows symlinks."
   `(("fc_tag" . ,org-fc-flashcard-tag)
     ("suspended_tag" . ,org-fc-suspended-tag)
     ("type_property" . ,org-fc-type-property)
+    ("cloze_type_property" . ,org-fc-cloze-type-property)
     ("created_property" . ,org-fc-created-property)
     ("review_data_drawer" . ,org-fc-review-data-drawer)))
 
@@ -1410,7 +1422,11 @@ Cards with no positions are removed from the index."
                   (time-less-p (plist-get pos :due) now))
                 (plist-get card :positions))))
           (unless (null due)
-            (plist-put card :positions due)
+            (plist-put
+             card :positions
+             (if (or (not org-fc-bury-siblings)
+                     (member (plist-get card :cloze-type) '(single enumeration)))
+                 due (list (car due))))
             (push card res)))))
     res))
 


### PR DESCRIPTION
Reviewing e.g. the front of a flashcard after the back makes it artificially easier, and I'd like to avoid that. The commit introduces a variable that allows setting the maximum times the same card will appear in a review session. It may be worth shuffling `due` before taking the `subseq`, but I guess it depends on how the cards are set up and I'm setting `org-fc-max-positions-per-review` to 1, so I have no experience to say what would be best. 