### PR TITLE
fix: (wrong-number-of-arguments (3 . 4) 2)

### DIFF
--- a/org-fc.el
+++ b/org-fc.el
@@ -1382,7 +1382,7 @@ same ID as the current card in the session."
      (org-fc-review-quit)
      (signal (car err) (cdr err)))))
 
-(define-obsolete-function-alias 'org-fc-review-rate-card 'org-fc-review-rate)
+(define-obsolete-function-alias 'org-fc-review-rate-card 'org-fc-review-rate "2020-07-02")
 
 (defun org-fc-review-rate-again ()
   "Rate the card at point with 'again'."


### PR DESCRIPTION
org-fc fails to load because `define-obsolete-function-alias` is called with wrong number of arguments.

Specify the required third argument when the function was deprecated.