### PR TITLE
(work-in-progress) Cards and positions

### DIFF
--- a/org-fc-algo-sm2.el
+++ b/org-fc-algo-sm2.el
@@ -151,16 +151,23 @@ EASE, BOX and INTERVAL are the current parameters of the card."
          (next-box
           (cond
            ;; If a card is rated easy, skip the learning phase
-           ((and (eq box 0) (eq rating 'easy)) 2)
+           ((and (eq box 0)
+                 (eq rating 'easy))
+            2)
            ;; If the review failed, go back to box 0
-           ((eq rating 'again) 0)
+           ((eq rating 'again)
+            0)
            ;; Otherwise, move forward one box
-           (t (1+ box))))
+           (t
+            (1+ box))))
          (next-interval
           (cond ((< next-box (length intervals))
                  (nth next-box intervals))
-                ((and (eq org-fc-algorithm 'sm2-v2) (eq rating 'hard)) (* 1.2 interval))
-                (t (org-fc-algo-sm2-fuzz (* next-ease interval))))))
+                ((and (eq org-fc-algorithm 'sm2-v2)
+                      (eq rating 'hard))
+                 (* 1.2 interval))
+                (t
+                 (org-fc-algo-sm2-fuzz (* next-ease interval))))))
     (list
      next-ease
      next-box

--- a/org-fc-algo-sm2.el
+++ b/org-fc-algo-sm2.el
@@ -161,12 +161,23 @@ EASE, BOX and INTERVAL are the current parameters of the card."
                  (nth next-box intervals))
                 ((and (eq org-fc-algorithm 'sm2-v2) (eq rating 'hard)) (* 1.2 interval))
                 (t (org-fc-algo-sm2-fuzz (* next-ease interval))))))
-    (list next-ease next-box next-interval)))
+    (list
+     next-ease
+     next-box
+     next-interval)))
 
 (defun org-fc-algo-sm2-initial-review-data (position)
   "Initial SM2 review data for POSITION."
-  (list position (org-fc-algo-sm2-ease-initial) 0 0
-        (org-fc-timestamp-in 0)))
+  (let* ((box 0)
+         (ease (org-fc-algo-sm2-ease-initial))
+         (interval 0)
+         (due (org-fc-timestamp-in interval)))
+    (list
+     position
+     ease
+     box
+     interval
+     due)))
 
 ;;; Footer
 

--- a/org-fc-core.el
+++ b/org-fc-core.el
@@ -243,12 +243,13 @@ Don't access directly! Use `org-fc-daily-new-limit--get-remaining'.")
 
 (cl-defmethod position-is-new ((pos org-fc-position))
   "Return t if POS is new; nil otherwise."
-  (= 0 (oref pos interval)))
+  (let ((interval (oref pos interval)))
+    (message (prin1-to-string interval))
+    (= 0 interval)))
 
 (defun org-fc-position--is-due (pos)
   "Return t if POS is due; else nil."
-  (time-less-p (oref pos due)
-               (current-time)))
+  (time-less-p (oref pos due) (current-time)))
 
 (defun org-fc-positions--remove-not-due (positions)
   "Remove not-due POSITIONS and return the rest."
@@ -277,8 +278,14 @@ Don't access directly! Use `org-fc-daily-new-limit--get-remaining'.")
   (if org-fc-daily-new-limit
       (if-let ((remaining-new (org-fc-daily-new-limit--get-remaining)))
           (--filter
-           (or (not (position-is-new it))
-               (>= (setq remaining-new (1- remaining-new)) 0))
+           (cond
+            ((not (position-is-new it))
+             t)
+            ((>= remaining-new 0)
+             (setq remaining-new (1- remaining-new))
+             t)
+            (t
+             nil))
            positions)
         positions)))
 

--- a/org-fc-core.el
+++ b/org-fc-core.el
@@ -25,6 +25,7 @@
 ;;; Code:
 
 (require 'outline)
+(require 'eieio)
 
 (require 'org-id)
 (require 'org-indent)
@@ -133,7 +134,137 @@ Does not apply to cloze single and cloze enumeration cards."
   :type 'boolean
   :group 'org-fc)
 
+;;; Types/Classes
+
+(defclass org-fc-card ()
+  ((created
+    :initform nil
+    :initarg :created)
+   (filetitle
+    :initform nil
+    :initarg :filetitle)
+   (tags
+    :initform nil
+    :initarg :tags)
+   (id
+    :initform nil
+    :initarg :id)
+   (inherited-tags
+    :initform nil
+    :initarg :inherited-tags)
+   (local-tags
+    :initform nil
+    :initarg :local-tags)
+   (path
+    :initform nil
+    :initarg :path)
+   (positions
+    ;; List of `org-fc-positions'
+    :initform nil
+    :initarg :positions)
+   (suspended
+    :initform nil
+    :initarg :suspended)
+   (title
+    :initform nil
+    :initarg :title)
+   (type
+    :initform nil
+    :initarg :type)))
+
+(defclass org-fc-position ()
+  ((box
+    :initform nil
+    :initarg :box)
+   (card
+    ;; `org-fc-card'
+    :initform nil
+    :initarg :card)
+   (due
+    :initform nil
+    :initarg :due)
+   (ease
+    :initform nil
+    :initarg :ease)
+   (interval
+    :initform nil
+    :initarg :interval)
+   (pos
+    :initform nil
+    :initarg :pos))
+  "Represents a single position.")
+
 ;;; Helper Functions
+
+;;;; org-fc-card
+(defun org-fc-cards--remove-suspended (cards)
+  "Return list of non-suspended `org-fc-card's."
+  (--filter
+   (not (oref it suspended))
+   cards))
+
+(defun org-fc-card--to-positions (card)
+  "Return list of `org-fc-position' extracted from CARD."
+  (mapcar
+   (lambda (pos)
+     (org-fc-position
+      :box (plist-get pos :box)
+      :card card
+      :due (plist-get pos :due)
+      :ease (plist-get pos :ease)
+      :interval (plist-get pos :interval)
+      :pos (plist-get pos :position)))
+   (oref card positions)))
+
+(defun org-fc-cards--to-positions (cards)
+  "Convert a list of `org-fc-card's to a list of `org-fc-positions's."
+  (cl-loop for card in cards
+           append (org-fc-card--to-positions card)))
+
+;;;; org-fc-position
+
+(defun org-fc-position--is-due (pos)
+  "Return t if POS is due; else nil."
+  (time-less-p (oref pos due)
+               (current-time)))
+
+(defun org-fc-positions--remove-not-due (positions)
+  "Remove not-due POSITIONS and return the rest."
+  (--filter
+   (not (org-fc-position--is-due it))
+   positions))
+
+(defun org-fc-positions--maybe-remove-siblings (positions)
+  "Conditionally remove siblings from POSITIONS and return the rest."
+  (if org-fc-bury-siblings
+      (let ((-compare-fn (lambda (a b)
+                           (equal (oref a id)
+                                  (oref b id)))))
+        (-uniq
+         positions))
+    positions))
+
+(defun org-fc-positions--maybe-shuffle (positions)
+  "Conditionally return a shuffled version of POSITIONS."
+  (if org-fc-shuffle-positions
+      (org-fc-shuffle positions)
+    positions))
+
+;;;; General
+
+(defun org-fc-shuffle (items)
+  "Return a shuffled version of ITEMS."
+  (let* ((randoms (cl-loop for _ below (length items)
+                           collect (cl-random 1.0)))
+         (zipped (-zip randoms
+                       items))
+         (sorted-zipped (sort zipped
+                              (lambda (a b)
+                                (> (car a)
+                                   (car b))))))
+    (mapcar
+     #'cdr
+     sorted-zipped)))
 
 (defun org-fc-member-p (path)
   "Check if PATH is member of one of the `org-fc-directories'."
@@ -528,6 +659,25 @@ Checks if the headline is a suspended card first."
   (org-fc-map-cards 'org-fc-unsuspend-card 'region))
 
 ;;; Indexing Cards
+
+(defun org-fc-index--to-cards (index)
+  "Convert an index to a list of `org-fc-card'."
+  (mapcar
+   (lambda (card)
+     (org-fc-card
+      :created (plist-get card :created)
+      :filetitle (plist-get card :filetitle)
+      :id (plist-get card :id)
+      :inherited-tags (plist-get card :inherited-tags)
+      :local-tags (plist-get card :local-tags)
+      :path (plist-get card :path)
+      :positions (plist-get card :positions)
+      :suspended (plist-get card :suspended)
+      :tags (plist-get card :tags)
+      :title (plist-get card :title)
+      :type (plist-get card :type)))
+   index))
+
 ;;;; Card Filters
 
 (defun org-fc--compile-filter (filter)
@@ -582,66 +732,6 @@ use `(and (type double) (tag \"math\"))'."
     (if filter (setq filter (org-fc--compile-filter filter)))
 
     (funcall org-fc-index-function paths filter)))
-
-(defun org-fc-index-flatten-card (card)
-  "Flatten CARD into a list of positions.
-Relevant data from the card is included in each position
-element."
-  (mapcar
-   (lambda (pos)
-     (list
-      :filetitle (plist-get card :filetitle)
-      :tags (plist-get card :tags)
-      :path (plist-get card :path)
-      :id (plist-get card :id)
-      :type (plist-get card :type)
-      :due (plist-get pos :due)
-      :position (plist-get pos :position)))
-   (plist-get card :positions)))
-
-(defun org-fc-index-filter-due (index)
-  "Filter INDEX to include only unsuspended due positions.
-Cards with no positions are removed from the index."
-  (let (res (now (current-time)))
-    (dolist (card index)
-      (unless (plist-get card :suspended)
-        (let ((due
-               (cl-remove-if-not
-                (lambda (pos)
-                  (time-less-p (plist-get pos :due) now))
-                (plist-get card :positions))))
-          (unless (null due)
-            (plist-put
-             card :positions
-             (if (or (not org-fc-bury-siblings)
-                     (member (plist-get card :cloze-type) '(single enumeration)))
-                 due (list (car due))))
-            (push card res)))))
-    res))
-
-(defun org-fc-index-positions (index)
-  "Return all positions in INDEX."
-  (mapcan (lambda (card) (org-fc-index-flatten-card card)) index))
-
-(defun org-fc-index-shuffled-positions (index)
-  "Return all positions in INDEX in random order.
-Positions are shuffled in a way that preserves the order of the
-  positions for each card."
-  ;; 1. assign each position a random number
-  ;; 2. flatten the list
-  ;; 3. sort by the random number
-  ;; 4. remove the random numbers from the result
-  (let ((positions
-         (mapcan
-          (lambda (card)
-            (let ((pos (org-fc-index-flatten-card card)))
-              (org-fc-zip
-               (org-fc-sorted-random (length pos))
-               pos)))
-          index)))
-    (mapcar
-     #'cdr
-     (sort positions (lambda (a b) (> (car a) (car b)))))))
 
 ;;; Demo Mode
 

--- a/org-fc-core.el
+++ b/org-fc-core.el
@@ -243,9 +243,11 @@ Don't access directly! Use `org-fc-daily-new-limit--get-remaining'.")
 
 (cl-defmethod position-is-new ((pos org-fc-position))
   "Return t if POS is new; nil otherwise."
-  (let ((interval (oref pos interval)))
-    (message (prin1-to-string interval))
-    (= 0 interval)))
+  (let* ((card (oref pos card))
+         (card-created (oref card created))
+         (position-due (oref pos due)))
+    (time-equal-p card-created
+                  position-due)))
 
 (defun org-fc-position--is-due (pos)
   "Return t if POS is due; else nil."
@@ -280,8 +282,9 @@ Don't access directly! Use `org-fc-daily-new-limit--get-remaining'.")
           (--filter
            (cond
             ((not (position-is-new it))
-             t)
-            ((>= remaining-new 0)
+             t
+             )
+            ((> remaining-new 0)
              (setq remaining-new (1- remaining-new))
              t)
             (t

--- a/org-fc-review.el
+++ b/org-fc-review.el
@@ -228,6 +228,7 @@ same ID as the current card in the session."
                (delta (- now org-fc-review--timestamp)))
           (org-fc-review-add-rating org-fc-review--session rating)
           (org-fc-review-update-data path id pos rating delta)
+          (message (prin1-to-string `(,is-new current-item)))
           (if (and org-fc-daily-new-limit
                    is-new)
               (setq org-fc-daily-new-limit--new-seen-today


### PR DESCRIPTION
I'm opening this pull request to get feedback on a work-in-progress which:

1. Adds `org-fc-card`: A representation of a single card
2. Adds `org-fc-position`: A representation of a single position
3. Refactors some reviewing processes to use lists of `org-fc-position`
4. Adds the ability to restrict the number of new cards added to the review queue each day (needs to be split out into its own pull request and integrated with #82)