### PR TITLE
Classes, user-defined filters, cards can block other cards

### DIFF
--- a/awk/index.awk
+++ b/awk/index.awk
@@ -39,6 +39,7 @@ BEGIN {
     type_property = or_default(type_property, "FC_TYPE");
     cloze_type_property = or_default(cloze_type_property, "FC_CLOZE_TYPE");
     created_property = or_default(created_property, "FC_CREATED");
+    blocked_by_property = or_default(blocked_by_property, "FC_BLOCKED_BY");
 
     # Small state machine to make sure cards are in the correct format
     state = 0;
@@ -164,6 +165,7 @@ $0 ~ review_data_drawer {
             cloze_type                                            \
             " :created " parse_time(properties[created_property]) \
             " :suspended " (suspended ? "t" : "nil")   \
+            " :blocked-by " escape_string(properties[blocked_by_property]) \
             " :inherited-tags " escape_string(inherited_tags)  \
             " :local-tags " escape_string(local_tags)          \
             " :positions (";

--- a/org-fc-algo-sm2.el
+++ b/org-fc-algo-sm2.el
@@ -140,6 +140,9 @@ INTERVAL is by a random factor between `org-fc-algo-sm2-fuzz-min' and
 EASE, BOX and INTERVAL are the current parameters of the card."
   (let* ((intervals (org-fc-algo-sm2-intervals))
          (changes (org-fc-algo-sm2-changes))
+         (box
+          ;; Treat a negative box value (i.e. a new position) as if it were 0.
+          (max box 0))
          (next-ease
           (if (< box 2)
               ease
@@ -151,21 +154,28 @@ EASE, BOX and INTERVAL are the current parameters of the card."
          (next-box
           (cond
            ;; If a card is rated easy, skip the learning phase
-           ((and (eq box 0) (eq rating 'easy)) 2)
+           ((and (eq box 0)
+                 (eq rating 'easy))
+            2)
            ;; If the review failed, go back to box 0
-           ((eq rating 'again) 0)
+           ((eq rating 'again)
+            0)
            ;; Otherwise, move forward one box
-           (t (1+ box))))
+           (t
+            (1+ box))))
          (next-interval
           (cond ((< next-box (length intervals))
                  (nth next-box intervals))
-                ((and (eq org-fc-algorithm 'sm2-v2) (eq rating 'hard)) (* 1.2 interval))
-                (t (org-fc-algo-sm2-fuzz (* next-ease interval))))))
+                ((and (eq org-fc-algorithm 'sm2-v2)
+                      (eq rating 'hard))
+                 (* 1.2 interval))
+                (t
+                 (org-fc-algo-sm2-fuzz (* next-ease interval))))))
     (list next-ease next-box next-interval)))
 
 (defun org-fc-algo-sm2-initial-review-data (position)
   "Initial SM2 review data for POSITION."
-  (let* ((box 0)
+  (let* ((box -1)
          (ease (org-fc-algo-sm2-ease-initial))
          (interval 0)
          (due (org-fc-timestamp-in interval)))

--- a/org-fc-awk.el
+++ b/org-fc-awk.el
@@ -49,7 +49,8 @@ With the '-L' option, 'find' follows symlinks."
     ("type_property" . ,org-fc-type-property)
     ("cloze_type_property" . ,org-fc-type-cloze-type-property)
     ("created_property" . ,org-fc-created-property)
-    ("review_data_drawer" . ,org-fc-review-data-drawer)))
+    ("review_data_drawer" . ,org-fc-review-data-drawer)
+    ("blocked_by_property" . ,org-fc-blocked-by-property)))
 
 (cl-defun org-fc-awk--command (file &optional &key variables input)
   "Generate the shell command for calling awk.
@@ -123,11 +124,13 @@ FILTER can be either nil or a function taking a single card as
             (plist-put file :cards
                        (mapcar
                         (lambda (card)
-                          (plist-put
-                           card :tags
-                           (org-fc-awk-combine-tags
-                            (plist-get card :inherited-tags)
-                            (plist-get card :local-tags))))
+                          (plist-put card :blocked-by (split-string
+                                                       (or (plist-get card :blocked-by)
+                                                           '())
+                                                       ","))
+                          (plist-put card :tags (org-fc-awk-combine-tags
+                                                 (plist-get card :inherited-tags)
+                                                 (plist-get card :local-tags))))
                         (plist-get file :cards))))
           (read output)))
       (error "Org-fc shell error: %s" output))))

--- a/org-fc-cache.el
+++ b/org-fc-cache.el
@@ -110,11 +110,13 @@ the AWK command and directories are not supported."
      (plist-put file :cards
                 (mapcar
                  (lambda (card)
-                   (plist-put
-                    card :tags
-                    (org-fc-awk-combine-tags
-                     (plist-get card :inherited-tags)
-                     (plist-get card :local-tags))))
+                   (plist-put card :blocked-by (split-string
+                                                (or (plist-get card :blocked-by)
+                                                    "")
+                                                ","))
+                   (plist-put card :tags (org-fc-awk-combine-tags
+                                          (plist-get card :inherited-tags)
+                                          (plist-get card :local-tags))))
                  (plist-get file :cards))))
    (read
     (shell-command-to-string
@@ -153,7 +155,7 @@ are renamed or deleted."
   :global t
   (if org-fc-cache-mode
       (org-fc-cache--enable)
-      (org-fc-cache--disable)))
+    (org-fc-cache--disable)))
 
 ;;; Coherence Check
 

--- a/org-fc-cache.el
+++ b/org-fc-cache.el
@@ -37,6 +37,7 @@
 (require 'org-fc-core)
 (require 'org-fc-awk)
 (require 'org-fc-review)
+(require 'org-fc-card)
 
 ;;; Queue / Processing of Files
 
@@ -163,12 +164,12 @@ are renamed or deleted."
 (defun org-fc-cache-coherence-check ()
   "Check if the entry at point is coherent with its cache representation.
 This is especially relevant w.r.t a card's due date / suspension state before review."
-  (org-fc-review-with-current-item cur
+  (org-fc-review-with-current-item position
     (if (org-fc-suspended-entry-p)
         (error "Trying to review a suspended card"))
-    (let* ((position (plist-get cur :position))
-           (review-data (org-fc-review-data-get))
-           (row (assoc position review-data #'string=))
+    (let* ((review-data (org-fc-review-data-get))
+           (pos (oref position pos))
+           (row (assoc pos review-data #'string=))
            (due (parse-iso8601-time-string (nth 4 row))))
       (unless (time-less-p due (current-time))
         (error "Trying to review a non-due card")))))

--- a/org-fc-card.el
+++ b/org-fc-card.el
@@ -36,6 +36,12 @@
     :type list
     :custom (repeat integer)
     :documentation "The time at which this card was created.")
+   (blocked-by
+    :initform nil
+    :initarg :blocked-by
+    :type list
+    :custom (repeat string)
+    :documentation "The IDs of cards which block this card.")
    (filetitle
     :initform ""
     :initarg :filetitle
@@ -86,6 +92,32 @@
     :initarg :type
     :type symbol
     :documentation "The org-fc-* card type (e.g. double or cloze).")))
+
+(defun org-fc-card--from-raw (raw-card)
+  "Return a `org-fc-card' constructed from RAW-CARD."
+  (let ((card (org-fc-card
+               :created (plist-get raw-card :created)
+               :filetitle (plist-get raw-card :filetitle)
+               :tags (plist-get raw-card :tags)
+               :id (plist-get raw-card :id)
+               :inherited-tags (plist-get raw-card :inherited-tags)
+               :local-tags (plist-get raw-card :local-tags)
+               :path (plist-get raw-card :path)
+               :suspended (plist-get raw-card :suspended)
+               :title (plist-get raw-card :title)
+               :type (plist-get raw-card :type))))
+    (oset card positions (mapcar
+                          (lambda (raw-position)
+                            "Return a `org-fc-position' constructed from RAW-POSITION."
+                            (org-fc-position
+                             :box (plist-get raw-position :box)
+                             :card card
+                             :due (plist-get raw-position :due)
+                             :ease (plist-get raw-position :ease)
+                             :interval (plist-get raw-position :interval)
+                             :pos (plist-get raw-position :position)))
+                          (plist-get raw-card :positions)))
+    card))
 
 ;;; Footer
 

--- a/org-fc-card.el
+++ b/org-fc-card.el
@@ -1,0 +1,94 @@
+;;; org-fc-card.el --- Represent a single card -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2020-2021  Leon Rische
+
+;; Author: Leon Rische <emacs@leonrische.me>
+;; Url: https://www.leonrische.me/pages/org_flashcards.html
+;; Package-requires: ((emacs "26.3") (org "9.3"))
+;; Version: 0.1.0
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+;;
+;;; Code:
+
+(require 'eieio)
+(require 'dash)
+
+(require 'org-fc-position)
+
+(defclass org-fc-card ()
+  ((created
+    :initform nil
+    :initarg :created
+    :type list
+    :custom (repeat integer)
+    :documentation "The time at which this card was created.")
+   (filetitle
+    :initform ""
+    :initarg :filetitle
+    :type string
+    :documentation "The title of the file which contains this card.")
+   (tags
+    :initform nil
+    :initarg :tags
+    :type list
+    :custom (repeat string)
+    :documentation "The tags on this card.")
+   (id
+    :initform ""
+    :initarg :id
+    :type string
+    :documentation "The org-id for this card.")
+   (inherited-tags
+    :initform ""
+    :initarg :inherited-tags
+    :type string
+    :documentation "Inherited tags in the form :taga:tagb:.")
+   (local-tags
+    :initform ""
+    :initarg :local-tags
+    :type string
+    :documentation "Tags on the card itself in the form :taga:tagb:.")
+   (path
+    :initform ""
+    :initarg :path
+    :type string
+    :documentation "Full path to the file which contains this card.")
+   (positions
+    :initform nil
+    :initarg :positions
+    :type list
+    :documentation "The `org-fc-position's for this card.")
+   (suspended
+    :initform nil
+    :initarg :suspended
+    :type boolean
+    :documentation "t when the card is suspended; nil otherwise.")
+   (title
+    :initform nil
+    :initarg :title
+    :type (or null string))
+   (type
+    :initform nil
+    :initarg :type
+    :type symbol
+    :documentation "The org-fc-* card type (e.g. double or cloze).")))
+
+;;; Footer
+
+(provide 'org-fc-card)
+
+;;; org-fc-card.el ends here

--- a/org-fc-core.el
+++ b/org-fc-core.el
@@ -29,6 +29,7 @@
 (require 'org-id)
 (require 'org-indent)
 (require 'org-element)
+(require 'org-fc-index)
 
 (require 'subr-x)
 
@@ -180,9 +181,6 @@ This is expected to be called on an card entry heading."
 Used to determine if a card uses the compact style."
   (not (null (org-fc-back-heading-position))))
 
-(defun org-fc-sorted-random (n)
-  "Generate a list of N sorted random numbers."
-  (sort (cl-loop for i below n collect (cl-random 1.0)) #'>))
 
 (defun org-fc-zip (as bs)
   "Zip two lists AS and BS."
@@ -565,83 +563,9 @@ use `(and (type double) (tag \"math\"))'."
              `(eq ',(if (stringp (cadr filter))
                         (intern (cadr filter))
                       (cadr filter))
-                  (plist-get ,card-var :type))))))
+               (plist-get ,card-var :type))))))
       `(lambda (,card-var)
          ,(compile-inner filter)))))
-
-(defun org-fc-index (context)
-  "Create an index for review CONTEXT."
-  (let ((paths (plist-get context :paths))
-        (filter (plist-get context :filter)))
-    ;; Handle path formats / symbols
-    (cond
-     ((or (null paths) (eq paths 'all)) (setq paths org-fc-directories))
-     ((eq paths 'buffer) (setq paths (list (buffer-file-name))))
-     ((stringp paths) (setq paths (list paths))))
-
-    (if filter (setq filter (org-fc--compile-filter filter)))
-
-    (funcall org-fc-index-function paths filter)))
-
-(defun org-fc-index-flatten-card (card)
-  "Flatten CARD into a list of positions.
-Relevant data from the card is included in each position
-element."
-  (mapcar
-   (lambda (pos)
-     (list
-      :filetitle (plist-get card :filetitle)
-      :tags (plist-get card :tags)
-      :path (plist-get card :path)
-      :id (plist-get card :id)
-      :type (plist-get card :type)
-      :due (plist-get pos :due)
-      :position (plist-get pos :position)))
-   (plist-get card :positions)))
-
-(defun org-fc-index-filter-due (index)
-  "Filter INDEX to include only unsuspended due positions.
-Cards with no positions are removed from the index."
-  (let (res (now (current-time)))
-    (dolist (card index)
-      (unless (plist-get card :suspended)
-        (let ((due
-               (cl-remove-if-not
-                (lambda (pos)
-                  (time-less-p (plist-get pos :due) now))
-                (plist-get card :positions))))
-          (unless (null due)
-            (plist-put
-             card :positions
-             (if (or (not org-fc-bury-siblings)
-                     (member (plist-get card :cloze-type) '(single enumeration)))
-                 due (list (car due))))
-            (push card res)))))
-    res))
-
-(defun org-fc-index-positions (index)
-  "Return all positions in INDEX."
-  (mapcan (lambda (card) (org-fc-index-flatten-card card)) index))
-
-(defun org-fc-index-shuffled-positions (index)
-  "Return all positions in INDEX in random order.
-Positions are shuffled in a way that preserves the order of the
-  positions for each card."
-  ;; 1. assign each position a random number
-  ;; 2. flatten the list
-  ;; 3. sort by the random number
-  ;; 4. remove the random numbers from the result
-  (let ((positions
-         (mapcan
-          (lambda (card)
-            (let ((pos (org-fc-index-flatten-card card)))
-              (org-fc-zip
-               (org-fc-sorted-random (length pos))
-               pos)))
-          index)))
-    (mapcar
-     #'cdr
-     (sort positions (lambda (a b) (> (car a) (car b)))))))
 
 ;;; Demo Mode
 

--- a/org-fc-core.el
+++ b/org-fc-core.el
@@ -78,6 +78,11 @@ Used to generate absolute paths to the awk scripts.")
   :type 'string
   :group 'org-fc)
 
+(defcustom org-fc-blocked-by-property "FC_BLOCKED_BY"
+  "Property used to store the cards creation time."
+  :type 'string
+  :group 'org-fc)
+
 (defcustom org-fc-created-property "FC_CREATED"
   "Property used to store the cards creation time."
   :type 'string

--- a/org-fc-index.el
+++ b/org-fc-index.el
@@ -1,0 +1,117 @@
+;;; org-fc-index.el --- Represent an index for review content -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2020-2021  Leon Rische
+
+;; Author: Leon Rische <emacs@leonrische.me>
+;; Url: https://www.leonrische.me/pages/org_flashcards.html
+;; Package-requires: ((emacs "26.3") (org "9.3"))
+;; Version: 0.1.0
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+;;
+;;; Code:
+
+(require 'eieio)
+(require 'dash)
+
+(require 'org-fc-lib)
+(require 'org-fc-card)
+(require 'org-fc-position)
+
+(defclass org-fc-index ()
+  ((cards
+    :initform nil
+    :initarg :cards
+    :type list
+    :documentation "The `org-fc-cards's for this index.")))
+
+(defun org-fc-index--from-context (context)
+  "Return an `org-fc-index' constructed from CONTEXT."
+  (let* ((context-filter (plist-get context :filter))
+         (filter (when context-filter
+                   (org-fc--compile-filter context-filter)))
+         (context-paths (plist-get context :paths))
+         (paths (cond ((or (null context-paths)
+                           (eq context-paths 'all))
+                       org-fc-directories)
+                      ((eq context-paths 'buffer)
+                       (list (buffer-file-name)))
+                      ((stringp context-paths)
+                       (list context-paths))))
+         (raw-index (funcall org-fc-index-function
+                             paths
+                             filter))
+         (cards (mapcar
+                 (lambda (raw-card)
+                   "Return a `org-fc-card' constructed from RAW-CARD."
+                   (let ((card (org-fc-card
+                                :created (plist-get raw-card :created)
+                                :filetitle (plist-get raw-card :filetitle)
+                                :tags (plist-get raw-card :tags)
+                                :id (plist-get raw-card :id)
+                                :inherited-tags (plist-get raw-card :inherited-tags)
+                                :local-tags (plist-get raw-card :local-tags)
+                                :path (plist-get raw-card :path)
+                                :suspended (plist-get raw-card :suspended)
+                                :title (plist-get raw-card :title)
+                                :type (plist-get raw-card :type))))
+                     (oset card positions (mapcar
+                                           (lambda (raw-position)
+                                             "Return a `org-fc-position' constructed from RAW-POSITION."
+                                             (org-fc-position
+                                              :box (plist-get raw-position :box)
+                                              :card card
+                                              :due (plist-get raw-position :due)
+                                              :ease (plist-get raw-position :ease)
+                                              :interval (plist-get raw-position :interval)
+                                              :pos (plist-get raw-position :position)))
+                                           (plist-get raw-card :positions)))
+                     card))
+                 raw-index)))
+    (org-fc-index
+     :cards cards)))
+
+(cl-defmethod org-fc-index--to-shuffled-positions ((index org-fc-index))
+  "Return all positions in INDEX in random order.
+
+Positions are shuffled in a way that preserves the order of the positions for each card."
+  (let* ((cards (oref index cards))
+         (positions (sort
+                     (mapcan
+                      (lambda (card)
+                        (let ((positions (oref card positions)))
+                          (-zip-pair (org-fc-sorted-random (length positions))
+                                     positions)))
+                      cards)
+                     (lambda (a b)
+                       (> (car a) (car b))))))
+    (mapcar #'cdr
+            positions)))
+
+(cl-defmethod org-fc-index--to-positions ((index org-fc-index))
+  "Return all positions in INDEX."
+  (let* ((cards (oref index cards)))
+    (mapcan
+     (lambda (card)
+       (oref card positions))
+     cards)))
+
+
+;;; Footer
+
+(provide 'org-fc-index)
+
+;;; org-fc-index.el ends here

--- a/org-fc-index.el
+++ b/org-fc-index.el
@@ -54,33 +54,8 @@
          (raw-index (funcall org-fc-index-function
                              paths
                              filter))
-         (cards (mapcar
-                 (lambda (raw-card)
-                   "Return a `org-fc-card' constructed from RAW-CARD."
-                   (let ((card (org-fc-card
-                                :created (plist-get raw-card :created)
-                                :filetitle (plist-get raw-card :filetitle)
-                                :tags (plist-get raw-card :tags)
-                                :id (plist-get raw-card :id)
-                                :inherited-tags (plist-get raw-card :inherited-tags)
-                                :local-tags (plist-get raw-card :local-tags)
-                                :path (plist-get raw-card :path)
-                                :suspended (plist-get raw-card :suspended)
-                                :title (plist-get raw-card :title)
-                                :type (plist-get raw-card :type))))
-                     (oset card positions (mapcar
-                                           (lambda (raw-position)
-                                             "Return a `org-fc-position' constructed from RAW-POSITION."
-                                             (org-fc-position
-                                              :box (plist-get raw-position :box)
-                                              :card card
-                                              :due (plist-get raw-position :due)
-                                              :ease (plist-get raw-position :ease)
-                                              :interval (plist-get raw-position :interval)
-                                              :pos (plist-get raw-position :position)))
-                                           (plist-get raw-card :positions)))
-                     card))
-                 raw-index)))
+         (cards (mapcar #'org-fc-card--from-raw
+                        raw-index)))
     (org-fc-index
      :cards cards)))
 

--- a/org-fc-lib.el
+++ b/org-fc-lib.el
@@ -1,0 +1,32 @@
+;;; org-fc-lib.el --- Helper functions for org-fc -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2020-2021  Leon Rische
+
+;; Author: Leon Rische <emacs@leonrische.me>
+;; Url: https://www.leonrische.me/pages/org_flashcards.html
+;; Package-requires: ((emacs "26.3") (org "9.3"))
+;; Version: 0.1.0
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+;;
+;;; Code:
+
+(defun org-fc-sorted-random (n)
+  "Generate a list of N sorted random numbers."
+  (sort (cl-loop for i below n collect (cl-random 1.0)) #'>))
+
+(provide 'org-fc-lib)
+;;; org-fc-lib.el ends here

--- a/org-fc-position.el
+++ b/org-fc-position.el
@@ -1,0 +1,88 @@
+;;; org-fc-position.el --- Represents a single position -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2020-2021  Leon Rische
+
+;; Author: Leon Rische <emacs@leonrische.me>
+;; Url: https://www.leonrische.me/pages/org_flashcards.html
+;; Package-requires: ((emacs "26.3") (org "9.3"))
+;; Version: 0.1.0
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+;;
+;;; Code:
+
+(require 'eieio)
+(require 'dash)
+
+(defclass org-fc-position ()
+  ((box
+    :initform 0
+    :initarg :box
+    :type (integer -1 *)
+    :documentation "The positions's current Leitner system box.")
+   (card
+    :initform nil
+    :initarg :card
+    :documentation "The `org-fc-card' which contains this position.")
+   (due
+    :initform nil
+    :initarg :due
+    :type list
+    :custom (repeat integer)
+    :documentation "The time at which this position is due.")
+   (ease
+    :initform 0
+    :initarg :ease
+    :type (or float integer)
+    :documentation "The ease factor.")
+   (interval
+    :initform 0
+    :initarg :interval
+    :type (or float integer)
+    :documentation "The interval, in days.")
+   (pos
+    :initform ""
+    :initarg :pos
+    :type (or integer string)
+    :documentation "The name of the position (e.g. \"front\" for double/normal or \"0\" for cloze)."))
+  "Represents a single position.")
+
+(cl-defmethod org-fc-position--is-due ((pos org-fc-position))
+  "Return t if POS is due; else nil."
+  (time-less-p (oref pos due) (current-time)))
+
+(cl-defmethod org-fc-positions--filter-due ((positions list))
+  "Filter POSITIONS to include only enabled and due positions."
+  (let ((due-enabled-positions (cl-loop for pos in positions
+                                        when (and (not (oref (oref pos card) suspended))
+                                                  (org-fc-position--is-due pos))
+                                        collect pos)))
+    (if org-fc-bury-siblings
+        (org-fc-positions--one-per-card due-enabled-positions)
+      due-enabled-positions)))
+
+(defun org-fc-positions--one-per-card (positions)
+  "Return filtered list of POSITIONS; only one position per card."
+  (let ((-compare-fn (lambda (a b)
+                       (equal (oref (oref a card) id)
+                              (oref (oref b card) id)))))
+    (-distinct positions)))
+
+;;; Footer
+
+(provide 'org-fc-position)
+
+;;; org-fc-position.el ends here

--- a/org-fc-review-session-rating.el
+++ b/org-fc-review-session-rating.el
@@ -1,0 +1,55 @@
+;;; org-fc-review-session-rating.el --- Represents a single review session rating -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2020-2021  Leon Rische
+
+;; Author: Leon Rische <emacs@leonrische.me>
+;; Url: https://www.leonrische.me/pages/org_flashcards.html
+;; Package-requires: ((emacs "26.3") (org "9.3"))
+;; Version: 0.1.0
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+;;
+;;; Code:
+
+(require 'eieio)
+
+(defclass org-fc-review-session-rating ()
+  ((total
+    :intiform 0
+    :initarg :total
+    :type integer)
+   (again
+    :intiform 0
+    :initarg :again
+    :type integer)
+   (hard
+    :intiform 0
+    :initarg :hard
+    :type integer)
+   (good
+    :intiform 0
+    :initarg :good
+    :type integer)
+   (easy
+    :intiform 0
+    :initarg :easy
+    :type integer)))
+
+;;; Footer
+
+(provide 'org-fc-review-session-rating)
+
+;;; org-fc-review-session-rating.el ends here

--- a/org-fc-review-session.el
+++ b/org-fc-review-session.el
@@ -1,0 +1,95 @@
+;;; org-fc-review-session.el --- Represents a single review session -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2020-2021  Leon Rische
+
+;; Author: Leon Rische <emacs@leonrische.me>
+;; Url: https://www.leonrische.me/pages/org_flashcards.html
+;; Package-requires: ((emacs "26.3") (org "9.3"))
+;; Version: 0.1.0
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+;;
+;;; Code:
+
+(require 'eieio)
+
+(require 'org-fc-review-session-rating)
+
+(defclass org-fc-review-session ()
+  ((current-item
+    :initform nil
+    :initarg :current-item
+    :documentation "The `org-fc-position' currently under review.")
+   (paused
+    :initform nil
+    :initarg :paused
+    :type boolean
+    :documentation "t when the review session is paused; nil otherwise")
+   (history
+    :initform nil
+    :initarg :paused)
+   (rating
+    :initform nil
+    :initarg :rating
+    :documentation "`org-fc-review-session-rating'.")
+   (positions
+    :initform nil
+    :initarg :positions
+    :documentation "List of `org-fc-position's.")))
+
+(defun org-fc-awk-stats-reviews-as-rating (stats key)
+  "Return the KEY of STATS as `org-fc-review-session-rating'."
+  (cl-destructuring-bind (&key total again hard good easy &allow-other-keys)
+      (pcase key
+        ('all
+         (plist-get stats :all))
+        ('month
+         (plist-get stats :month))
+        ('week
+         (plist-get stats :week))
+        ('day
+         (plist-get stats :day)))
+    (org-fc-review-session-rating
+     :total total
+     :again again
+     :hard hard
+     :good good
+     :easy easy)))
+
+(cl-defmethod org-fc-review-session--from-positions ((positions list))
+  "Create a new review session with POSITIONS."
+  (let ((rating (if-let ((stats (org-fc-awk-stats-reviews)))
+                    (org-fc-awk-stats-reviews-as-rating stats 'day)
+                  (org-fc-review-session-rating))))
+    (org-fc-review-session
+     :positions positions
+     :rating rating)))
+
+(cl-defmethod org-fc-review-session--add-rating ((session org-fc-review-session) rating-to-add)
+  "Store RATING in the review history of SESSION."
+  (with-slots (rating) session
+    (cl-case rating
+      ('again (cl-incf (oref rating again)))
+      ('hard (cl-incf (oref rating hard)))
+      ('good (cl-incf (oref rating good)))
+      ('easy (cl-incf (oref rating easy))))
+    (cl-incf (oref rating total))))
+
+;;; Footer
+
+(provide 'org-fc-review-session)
+
+;;; org-fc-review-session.el ends here

--- a/org-fc-review.el
+++ b/org-fc-review.el
@@ -114,6 +114,9 @@ Valid contexts:
            (positions (if org-fc-shuffle-positions
                           (org-fc-index--to-shuffled-positions index)
                         (org-fc-index--to-positions index)))
+           (positions (--filter
+                       (not (org-fc-position--is-blocked it))
+                       positions))
            (positions (org-fc-positions--filter-due positions)))
       ;; Allow users to apply further filtering to the positions.
       (dolist (filter-fn org-fc-review-position-filters)

--- a/org-fc-review.el
+++ b/org-fc-review.el
@@ -76,6 +76,10 @@ Hide title for individual cards by adding the :notitle: tag."
   :type 'boolean
   :group 'org-fc)
 
+(defcustom org-fc-review-position-filters '()
+  "Filters run before a review session starts to restrict the positions to review."
+  :group 'org-fc)
+
 ;;; Variables
 
 (defvar org-fc-review--session nil
@@ -111,6 +115,10 @@ Valid contexts:
                           (org-fc-index--to-shuffled-positions index)
                         (org-fc-index--to-positions index)))
            (positions (org-fc-positions--filter-due positions)))
+      ;; Allow users to apply further filtering to the positions.
+      (dolist (filter-fn org-fc-review-position-filters)
+        (setq
+         positions (funcall filter-fn positions)))
       (if (null positions)
           (message "No positions due right now.")
         (progn


### PR DESCRIPTION
This pull request contains changes addressing:

- Adding classes `org-fc-card`, `org-fc-position`, `org-fc-review-session`, and `org-fc-review-session-rating`
- Allows users to define custom filters to reduce the set of positions for review (TODO: Integrate this with the concept of a `context`)
- Allow cards to block other cards

I've included everything in one pull request as it's become a hassle to maintain separate pull requests here and a merged branch for my own local config. I'm happy to split it up when the time comes to merge things in. This pull request can serve as a center for review in the meantime.

Regarding https://github.com/l3kn/org-fc/issues/106#issuecomment-1336137517: I think my changes to how cards/positions are shuffled should resolve this concern.