### PR TITLE
Fix: When finding .org files, explicitly look for only files

### DIFF
--- a/org-fc-awk.el
+++ b/org-fc-awk.el
@@ -37,7 +37,7 @@ Matches all .org files ignoring ones with names don't start with
 a '.' to exclude temporary / backup files.
 With the '-L' option, 'find' follows symlinks."
   (format
-   "find -L %s -name \"*.org\" -not -name \".*\" -print0"
+   "find -L %s -type f -name \"*.org\" -not -name \".*\" -print0"
    (mapconcat
     (lambda (path) (shell-quote-argument (expand-file-name path)))
     paths " ")))


### PR DESCRIPTION
I hit this error when I moved `org-fc-directories` from a dedicated directory to my generic directory containing all org files. In this directory, I was also archiving webpages which I found interesting, using `org-board`. In one case, the website I was archiving from was a `.org` domain. This led the AWK script to add the following malformed data in the parsing output:

```
(:path \"/data/14/195382-E1EB-48A1-9147-1436EE1E3011/2023-10-04T21:48:25+0530/corfield.org\" :cards (
gawk: /.emacs.d/el-get/org-fc/awk/index.awk:63: warning:
command line argument
`/data/14/195382-E1EB-48A1-9147-1436EE1E3011/2023-10-04T21:48:25+0530/corfield.org'
is a directory: skipped
```

This breaks the function `org-fc-awk-index` with a `End of file during parsing` error.

One fix is to ensure that we only look at *files* ending with a `.org` extension, which is what this commit implements.