### PR TITLE
tr workaround for busybox grep not supporting --null

### DIFF
--- a/org-fc-awk.el
+++ b/org-fc-awk.el
@@ -44,7 +44,7 @@ Matches all .org files ignoring ones with names don't start with
 a `.' to exclude temporary / backup files.
 With the `-L' option, `find' follows symlinks."
   (format
-   "find -L %s -name \".*\" -prune -o -name \"[^.]*.org\" -type f -exec grep -l --null \"^:%s:\" {} \\+"
+   "find -L %s -name \".*\" -prune -o -name \"[^.]*.org\" -type f -exec grep -l \"^:%s:\" {} \\+ | tr \"\\n\" \"\\0\""
    (mapconcat
     (lambda (path) (shell-quote-argument (expand-file-name path)))
     paths " ")


### PR DESCRIPTION
Workaround that fixes #125 for me on PostmarketOS (alpine linux) phone with busybox find, grep, and tr