### PR TITLE
Fix the `find` command error on Windows

### DIFF
--- a/org-fc-awk.el
+++ b/org-fc-awk.el
@@ -44,7 +44,7 @@ Matches all .org files ignoring ones with names don't start with
 a `.' to exclude temporary / backup files.
 With the `-L' option, `find' follows symlinks."
   (format
-   "find -L %s -name \".*\" -prune -o -name \"[^.]*.org\" -type f -exec grep -l --null \"^[ \\t]*:%s:\" {} \\+"
+   "find -L %s -name \".*\" -prune -o -name \"[^.]*.org\" -type f -exec grep -l --null \"^[ \\t]*:%s:\" {} +"
    (mapconcat
     (lambda (path) (shell-quote-argument (expand-file-name path)))
     paths " ")


### PR DESCRIPTION
When using `+` as the terminator for the `-exec` in the `find` command, the backslash is unnecessary, which for unknown reasons works fine on GNU/Linux but produces the following error on Windows:

```
find: missing argument to `-exec'
```

This PR fixes the issue and has been tested on both Windows and GNU/Linux.