### PR TITLE
[WIP] FSRS Impementation by wrapping Python

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "python/py-fsrs"]
+	path = python/py-fsrs
+	url = https://github.com/open-spaced-repetition/py-fsrs

--- a/org-fc-algo-fsrs.el
+++ b/org-fc-algo-fsrs.el
@@ -1,0 +1,248 @@
+;;; org-fc-algo-fsrs.el --- Interface to python-based FSRS algorithm -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2025  Cash Prokop-Weaver
+;; Copyright (C) 2025  Leon Rische
+
+;; Author: Cash Prokop-Weaver <cash@cashpw.com>
+;; Author: Leon Rische <emacs@leonrische.me>
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+;;
+;;
+;;
+;;; Code:
+
+(require 'cl-lib)
+(require 'eieio)
+(require 'eieio-base)
+
+(require 'org-fc-core)
+(require 'org-fc-awk)
+(require 'org-fc-dashboard)
+
+
+;;;; Configuration
+
+(defcustom org-fc-algo-fsrs6-parameters
+  '(0.2172
+    1.1771
+    3.2602
+    16.1507
+    7.0114
+    0.57
+    2.0966
+    0.0069
+    1.5261
+    0.112
+    1.0178
+    1.849
+    0.1133
+    0.3127
+    2.2934
+    0.2191
+    3.0004
+    0.7536
+    0.3332
+    0.1437
+    0.2)
+  "The model weights of the FSRS scheduler."
+  :type '(repeat float)
+  :group 'org-fc)
+
+(defcustom org-fc-algo-fsrs6-desired-retention 0.8
+  "The desired retention rate of cards scheduled with the scheduler."
+  :type 'float
+  :group 'org-fc)
+
+(defcustom org-fc-algo-fsrs6-learning-steps
+  '(60 600)
+  "Small time intervals that schedule cards in the Learning state, in seconds."
+  :type '(repeat sexp)
+  :group 'org-fc)
+
+(defcustom org-fc-algo-fsrs6-relearning-steps '(600)
+  "Small time intervals that schedule cards in the Relearning state, in seconds."
+  :type '(repeat sexp)
+  :group 'org-fc)
+
+(defcustom org-fc-algo-fsrs6-maximum-interval (* 100 365)
+  "The maximum number of days a Review-state card can be scheduled into the future"
+  :type 'number
+  :group 'org-fc)
+
+(defcustom org-fc-algo-fsrs6-enable-fuzzing t
+  "Whether to apply a small amount of random 'fuzz' to calculated intervals."
+  :type 'boolean
+  :group 'org-fc)
+
+;;;; Helper Functions
+
+(defun org-fc-algo-fsrs6--plist-to-alist (plist)
+  (cl-loop for (key val) on plist by #'cddr collect (cons key val)))
+
+;;;; Python CLI Interaction
+
+(defun org-fc-algo-fsrs6--cli-wrap-json (request args)
+  "Run the python interface with json-encoded REQUEST as stdin,
+then return the parsed json response."
+  (let* ((default-directory
+          (file-name-as-directory
+           (expand-file-name "python" org-fc-source-path)))
+         (json-object-type 'plist)
+         (json-key-type 'symbol)
+         (return-data
+          (with-temp-buffer
+            (insert (json-encode request))
+            (message (json-encode request))
+            (save-excursion
+              (apply
+               #'call-process-region
+               (point-min) (point-max)
+               "python" nil t nil "algo_fsrs6.py"
+               args))
+            (message (buffer-string))
+            (json-read))))
+    return-data))
+
+(defun org-fc-algo-fsrs6--cli-get-initial ()
+  (org-fc-algo-fsrs6--cli-wrap-json
+   nil
+   (list "initial" "--now" (org-fc-timestamp-in 0))))
+
+(defun org-fc-algo-fsrs6--cli-get-next (current rating)
+  ;; Note: json-encode expects alists while other parts of org-fc use
+  ;; plists, so we need to convert here.
+  ;; When reading json, this can be configured but apparently not when
+  ;; writing.
+  (org-fc-algo-fsrs6--cli-wrap-json
+   `((scheduler
+      .
+      ((parameters . ,(vconcat org-fc-algo-fsrs6-parameters))
+       (desired-retention . ,org-fc-algo-fsrs6-desired-retention)
+       (relearning-steps . ,(vconcat org-fc-algo-fsrs6-relearning-steps))
+       (learning-steps . ,(vconcat org-fc-algo-fsrs6-learning-steps))
+       (maximum-interval . ,org-fc-algo-fsrs6-maximum-interval)
+       (enable-fuzzing . ,org-fc-algo-fsrs6-enable-fuzzing)))
+     (card . ,current)
+     (rating . ,rating))
+   (list "review" "--now" (org-fc-timestamp-in 0))))
+
+;;;; Main Algorithm Interface
+
+(defclass org-fc-algo-fsrs6 (eieio-singleton org-fc-algo) ())
+
+(cl-defmethod org-fc-algo-headers ((_algo org-fc-algo-fsrs6))
+  '(position state step stability difficulty due last-review))
+
+(cl-defmethod org-fc-algo-initial-review-data ((_algo org-fc-algo-fsrs6) name)
+  "Initial FSRS_6 review data for position NAME."
+  (list*
+   'position
+   name
+   (org-fc-algo-fsrs6--cli-get-initial)))
+
+(defun org-fc-algo-fsrs--parse-optional-str (v)
+  (if (equalp v "nil") nil v))
+
+(defun org-fc-algo-fsrs--parse-optional-number (v)
+  (if (equalp v "nil") nil (string-to-number v)))
+
+(cl-defmethod org-fc-algo-next-review-data
+  ((_algo org-fc-algo-fsrs6) current rating)
+  "Calculate the next parameters, given the CURRENT parameters and a RATING."
+  (let ((next-data (org-fc-algo-fsrs6--cli-get-next
+               `((state . ,(string-to-number (plist-get current 'state)))
+                 (step . ,(org-fc-algo-fsrs--parse-optional-number (plist-get current 'step)))
+                 (stability . ,(org-fc-algo-fsrs--parse-optional-number (plist-get current 'stability)))
+                 (difficulty . ,(org-fc-algo-fsrs--parse-optional-number (plist-get current 'difficulty)))
+                 (due . ,(plist-get current 'due))
+                 (last-review . ,(org-fc-algo-fsrs--parse-optional-str (plist-get current 'last-review))))
+               rating)))
+    (list
+     'state (format "%d" (plist-get next-data 'state))
+     'step (format "%s" (plist-get next-data 'step))
+     'stability (format "%f" (plist-get next-data 'stability))
+     'difficulty (format "%f" (plist-get next-data 'difficulty))
+     'due (plist-get next-data 'due)
+     'last-review (plist-get next-data 'last-review))))
+
+(cl-defmethod org-fc-algo-log-review ((_algo org-fc-algo-fsrs6) (position org-fc-position) current rating delta)
+  (let* ((card (oref position card))
+	       (file (oref card file))
+	       (elements
+	        (list
+	         (org-fc-timestamp-in 0)
+	         (oref file path)
+	         (oref card id)
+	         (oref position name)
+           ;; Leave columns used by SM2 algorithm empty
+           ""
+           ""
+           ""
+	         (symbol-name rating)
+	         (format "%.2f" delta)
+	         (symbol-name 'fsrs6))))
+    (append-to-file
+     (format "%s\n" (mapconcat #'identity elements "\t"))
+     nil
+     org-fc-review-history-file)))
+
+;; NOTE: This is a full duplicate of the version in SM2
+(cl-defmethod org-fc-algo-update-review-data ((algo org-fc-algo-fsrs6) (position org-fc-position) rating delta)
+  "Update the review data of a POSITION.
+Also add a new entry in the review history file. RATING is a
+review rating and DELTA the time in seconds between showing and
+rating the card."
+  (let* ((name (oref position name))
+	       (review-data (org-fc-review-data-parse (org-fc-algo-headers algo)))
+	       (current (org-fc-review-data-get-row review-data name)))
+
+    (unless current
+      (error "No review data row found for this position"))
+
+    (org-fc-algo-log-review algo position current rating delta)
+
+    (org-fc-review-data-update-row
+     review-data name
+     (org-fc-algo-next-review-data algo current rating))
+    (org-fc-review-data-write review-data)))
+
+;; NOTE: This is a full duplicate of the version in SM2
+(cl-defmethod org-fc-algo-review-history ((_algo org-fc-algo-fsrs6) card-id position-name)
+  "Review history for a given CARD-ID and POSITION name.
+Returns nil if there is no history file."
+  (when (file-exists-p org-fc-review-history-file)
+    (let ((output
+           (shell-command-to-string
+            (org-fc-awk--command
+             ;; NOTE: I expected to use different history files for different algorithms
+             ;; but sharing a file and leaving columns empty seems more elegant now.
+             ;; TODO: Rename the file again
+             "awk/review_history_sm2.awk"
+             :input org-fc-review-history-file
+	           :variables `(("filter_card_id" . ,(or card-id "any"))
+			                    ("filter_position_name" . ,(or position-name "any")))))))
+      (if (string-prefix-p "(" output)
+          (read output)
+        (error "Org-fc shell error: %s" output)))))
+
+(org-fc-register-algo 'fsrs6 org-fc-algo-fsrs6)
+
+;;; Footer
+
+(provide 'org-fc-algo-fsrs)
+
+;;; org-fc-algo-sm2.el ends here

--- a/python/algo_fsrs6.py
+++ b/python/algo_fsrs6.py
@@ -1,0 +1,161 @@
+# Copyright (C) 2025  Cash Prokop-Weaver
+# Copyright (C) 2025  Leon Rische
+
+# Author: Cash Prokop-Weaver <cash@cashpw.com>
+# Author: Leon Rische <emacs@leonrische.me>
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+
+import sys
+import logging
+import json
+from pathlib import Path
+
+# Load the fsrs code shipped with org-fc
+base = Path(__file__).resolve().parent
+sys.path.insert(0, str(base / "py_fsrs"))
+from py_fsrs import fsrs
+import argparse
+from datetime import datetime, timezone
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s"
+)
+
+def value_from_emacs(value: str):
+    if value == "nil":
+        return None
+    return value
+
+# Try to stick to language conventions
+def keys_to_emacs(d: dict) -> dict:
+    return {
+        k.replace("_", "-"): keys_to_emacs(v) if isinstance(v, dict) else v
+        for k, v in d.items()
+    }
+
+def keys_from_emacs(d: dict) -> dict:
+    return {
+        k.replace("-", "_"): keys_from_emacs(v) if isinstance(v, dict) else value_from_emacs(v)
+        for k, v in d.items()
+    }
+
+RATINGS = {
+    "again": fsrs.Rating.Again,
+    "hard": fsrs.Rating.Hard,
+    "good": fsrs.Rating.Good,
+    "easy": fsrs.Rating.Easy,
+}
+
+def _print_card(card: fsrs.Card):
+    card_dict = card.to_dict()
+    # Org-fc does not make use of the card_id, so we remove it
+    del card_dict["card_id"]
+
+    if card.due is not None:
+        card_dict["due"] = card.due.isoformat().replace("+00:00", "Z")
+    if card.last_review is not None:
+        card_dict["last_review"] = card.last_review.isoformat().replace("+00:00", "Z")
+
+    card_dict = keys_to_emacs(card_dict)
+    print(json.dumps(card_dict, indent=2))
+
+
+def initial():
+    """Generate an initial FSRS card and print it in Emacs-friendly format.
+    Optionally overwrite the card due date with --now argument.
+    """
+
+    parser = argparse.ArgumentParser(description="Generate initial FSRS card")
+    parser.add_argument("--now", type=str, help="Overwrite the card due date (ISO format)")
+    args, _ = parser.parse_known_args(sys.argv[2:])
+
+    card = fsrs.Card()
+
+    # Overwrite due date if --now is provided
+    if args.now is not None:
+        try:
+            # Parse ISO formatted string to datetime and back to ISO string
+            card.due = datetime.fromisoformat(args.now)
+        except ValueError:
+            logging.error("Invalid date format for --now. Use ISO format (YYYY-MM-DDTHH:MM:SS).")
+            sys.exit(1)
+
+    _print_card(card)
+
+def review():
+    """Process a review and print the updated FSRS card in Emacs-friendly format."""
+    parser = argparse.ArgumentParser(description="Review FSRS card")
+    parser.add_argument("--now", type=str, help="Overwrite the current datetime (ISO format)")
+    args, _ = parser.parse_known_args(sys.argv[2:])
+
+    # Default to current UTC time
+    now = datetime.now(timezone.utc)
+    # Overwrite if --now is provided
+    if args.now is not None:
+        try:
+            # Parse ISO formatted string to datetime and back to ISO string
+            now = datetime.fromisoformat(args.now)
+        except ValueError:
+            logging.error("Invalid date format for --now. Use ISO format (YYYY-MM-DDTHH:MM:SS).")
+            sys.exit(1)
+
+    json_str = sys.stdin.read()
+    try:
+        request = json.loads(json_str)
+    except json.JSONDecodeError as e:
+        logging.error(f"Failed to parse JSON: {e}")
+        sys.exit(1)
+
+    scheduler_dict = request["scheduler"]
+    scheduler_dict = keys_from_emacs(scheduler_dict)
+
+    card_dict = request["card"]
+    card_dict = keys_from_emacs(card_dict)
+
+    # Mock the card_id
+    card_dict["card_id"] = 0
+
+    scheduler = fsrs.Scheduler.from_dict(scheduler_dict)
+    card = fsrs.Card.from_dict(card_dict)
+
+    # response_dict = card.to_dict()
+    response_dict = scheduler.to_dict()
+    response_dict = keys_to_emacs(response_dict)
+
+    try:
+        rating = RATINGS[request["rating"]]
+    except KeyError:
+        logging.error(f"Invalid or missing rating: %s", request.get("rating"))
+
+    new_card, _revlog = scheduler.review_card(card, rating, review_datetime=now, review_duration=request.get("duration", None))
+
+    _print_card(new_card)
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        logging.error("Usage: python algo_fsrs6.py [initial|review]")
+        sys.exit(1)
+
+    command = sys.argv[1]
+    if command == "initial":
+        initial()
+    elif command == "review":
+        review()
+    else:
+        logging.error(f"Unknown command: {command}")
+        logging.info("Available commands: initial, review")
+        sys.exit(1)

--- a/tests/erts/card_init_normal_fsrs6.erts
+++ b/tests/erts/card_init_normal_fsrs6.erts
@@ -1,0 +1,20 @@
+Name: Case 1
+
+=-=
+* Front
+Back
+=-=
+* Front                                                                  :fc:
+:PROPERTIES:
+:FC_CREATED: 1970-01-01T00:00:00Z
+:FC_TYPE:  normal
+:FC_ALGO:  fsrs6
+:ID:       dummy-id
+:END:
+:REVIEW_DATA:
+| position | state | step | stability | difficulty | due                  | last-review |
+|----------+-------+------+-----------+------------+----------------------+-------------|
+| front    |     1 |    0 | nil       | nil        | 1970-01-01T00:00:00Z | nil         |
+:END:
+Back
+=-=-=

--- a/tests/erts/card_rate_normal_fsrs6.erts
+++ b/tests/erts/card_rate_normal_fsrs6.erts
@@ -1,0 +1,31 @@
+Name: Case 1
+
+=-=
+* Front                                                                  :fc:
+:PROPERTIES:
+:FC_CREATED: 1970-01-01T00:00:00Z
+:FC_TYPE:  normal
+:FC_ALGO:  fsrs6
+:ID:       dummy-id
+:END:
+:REVIEW_DATA:
+| position | state | step | stability | difficulty | due                  | last-review |
+|----------+-------+------+-----------+------------+----------------------+-------------|
+| front    |     1 |    0 | nil       | nil        | 1970-01-01T00:00:00Z | nil         |
+:END:
+Back
+=-=
+* Front                                                                  :fc:
+:PROPERTIES:
+:FC_CREATED: 1970-01-01T00:00:00Z
+:FC_TYPE:  normal
+:FC_ALGO:  fsrs6
+:ID:       dummy-id
+:END:
+:REVIEW_DATA:
+| position | state | step | stability | difficulty | due                  | last-review          |
+|----------+-------+------+-----------+------------+----------------------+----------------------|
+| front    |     1 |    1 |  3.260200 |   4.884632 | 1970-01-01T00:10:00Z | 1970-01-01T00:00:00Z |
+:END:
+Back
+=-=-=

--- a/tests/org-fc-algo-fsrs-test.el
+++ b/tests/org-fc-algo-fsrs-test.el
@@ -1,0 +1,60 @@
+(require 'org-fc)
+(require 'org-fc-test-helper)
+(require 'org-fc-algo-fsrs)
+(require 'ert)
+
+(ert-deftest org-fc-algo-fsrs-test-initial ()
+  (org-fc-test-with-overwrites
+   (org-fc-test-overwrite-fun time-to-seconds (lambda () 0))
+   (assert
+    (equal (org-fc-algo-initial-review-data (org-fc-algo-fsrs6) "name")
+           '(position "name" state 1 step 0 stability nil difficulty nil due "1970-01-01T00:00:00Z" last-review nil)))))
+
+(ert-deftest org-fc-algo-fsrs-test-step ()
+  (org-fc-test-with-overwrites
+   (org-fc-test-overwrite-fun time-to-seconds (lambda () 0))
+   (assert
+    (equal
+     (org-fc-algo-fsrs6--cli-get-next
+      '((position . "name") (state . 1) (step . 0) (stability . nil) (difficulty . nil) (due . "1970-01-01T00:00:00Z") (last-review . nil))
+      "good")
+     '(state 1 step 1 stability 3.2602 difficulty 4.884631634813845 due "1970-01-01T00:10:00Z" last-review "1970-01-01T00:00:00Z")))))
+
+(ert-deftest org-fc-algo-fsrs6-test-card-init-normal ()
+  (ert-test-erts-file
+   (org-fc-test-fixture "erts/card_init_normal_fsrs6.erts")
+   (lambda ()
+     (org-fc-test-with-overwrites
+      (org-fc-test-overwrite-fun
+       org-fc-select-algo
+       (lambda () "fsrs6"))
+      (org-fc-test-overwrite-fun
+       time-to-seconds
+       (lambda () 0))
+      (org-fc-test-overwrite-fun
+       org-id-get
+       (lambda (&rest _args)
+	 (org-entry-put (point) "ID" "dummy-id")
+	 "dummy-id"))
+      (org-mode)
+      (goto-char (point-min))
+      (org-fc-type-normal-init)))))
+
+(ert-deftest org-fc-algo-fsrs6-test-card-rate-normal ()
+  (ert-test-erts-file
+   (org-fc-test-fixture "erts/card_rate_normal_fsrs6.erts")
+   (lambda ()
+     (let* ((file (org-fc-file :path "mock-path"))
+	    (card (org-fc-card :file file :id "mock-id" :algo (org-fc-algo-fsrs6)))
+	    (position (org-fc-position :card card :name "front")))
+       (org-fc-test-with-overwrites
+	(org-fc-test-overwrite-fun
+	 time-to-seconds
+	 (lambda () 0))
+	(org-fc-test-overwrite-fun
+	 org-fc-review-history-add
+	 (lambda (data) nil))
+
+	(org-mode)
+	(goto-char (point-min))
+	(org-fc-review-update-data position 'good 0))))))


### PR DESCRIPTION
Based on code in https://github.com/l3kn/org-fc/issues/129 but passing card & scheduler state via JSON instead of using command line arguments, which hopefully is flexible enough to allow rating or rescheduling multiple cards at once.

## Missing

- [ ] Test correctness of FSRS review progression
- [ ] Make sure the dashboard still works with FSRS review history entries